### PR TITLE
implemented f04 hierarchical address

### DIFF
--- a/shared/src/address/errors.rs
+++ b/shared/src/address/errors.rs
@@ -32,6 +32,8 @@ pub enum Error {
     Base32Decoding(#[from] DecodeError),
     #[error("Cannot get id from non id address")]
     NonIDAddress,
+    #[error("Invalid Hierarchical Address")]
+    InvalidHierarchicalAddr,
 }
 
 impl From<num::ParseIntError> for Error {

--- a/shared/src/address/protocol.rs
+++ b/shared/src/address/protocol.rs
@@ -19,6 +19,8 @@ pub enum Protocol {
     Actor = 2,
     /// BLS key addressing
     BLS = 3,
+    /// Hierarchical address
+    Hierarchical = 4,
 }
 
 impl Protocol {

--- a/shared/tests/address_test.rs
+++ b/shared/tests/address_test.rs
@@ -291,7 +291,7 @@ fn invalid_string_addresses() {
             expected: Error::UnknownNetwork,
         },
         StringAddrVec {
-            input: "f4gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y",
+            input: "f5gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y",
             expected: Error::UnknownProtocol,
         },
         StringAddrVec {
@@ -363,7 +363,7 @@ fn invalid_byte_addresses() {
     let test_vectors = &[
         // Unknown Protocol
         StringAddrVec {
-            input: vec![4, 4, 4],
+            input: vec![5, 4, 4],
             expected: Error::UnknownProtocol,
         },
         // ID protocol


### PR DESCRIPTION
_NOTE: The implementation of f04 addresses has departed a bit from the original implementation from the MVP in order to use fixed size addresses. This change should be propagated to the Go implementation: https://github.com/adlrocha/go-address_